### PR TITLE
FIX : Retours Sprint 42

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,6 +1,7 @@
 # CHANGELOG DISTRIBUTIONLIST FOR [DOLIBARR ERP CRM](https://www.dolibarr.org)
 
 ## Unreleased
+- FIX : Suppression du champ date cloture dans popup de confirmation + MAJ date cloture sur cloture - *15/06/2021* - 1.1.3 
 - FIX : Impossibilité de valider une liste de diffusion lorsqu'elle est vide - *15/06/2021* - 1.1.2
 - FIX : Ajout du champ "Date de cloture" sur formulaire de creation - *14/06/2021* - 1.1.1
 - NEW : Séparation des permissions de création/modification - *02/06/2021* - 1.1.0

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,6 +1,7 @@
 # CHANGELOG DISTRIBUTIONLIST FOR [DOLIBARR ERP CRM](https://www.dolibarr.org)
 
 ## Unreleased
+- FIX : Ajout du champ "Date de cloture" sur formulaire de creation - *14/06/2021* - 1.1.1
 - NEW : Séparation des permissions de création/modification - *02/06/2021* - 1.1.0
 
 ## 1.0

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,6 +1,7 @@
 # CHANGELOG DISTRIBUTIONLIST FOR [DOLIBARR ERP CRM](https://www.dolibarr.org)
 
 ## Unreleased
+- FIX : Impossibilité de valider une liste de diffusion lorsqu'elle est vide - *15/06/2021* - 1.1.2
 - FIX : Ajout du champ "Date de cloture" sur formulaire de creation - *14/06/2021* - 1.1.1
 - NEW : Séparation des permissions de création/modification - *02/06/2021* - 1.1.0
 

--- a/class/distributionlist.class.php
+++ b/class/distributionlist.class.php
@@ -100,7 +100,7 @@ class DistributionList extends CommonObject
 		'label' => array('type'=>'varchar(255)', 'label'=>'Label', 'enabled'=>'1', 'position'=>30, 'notnull'=>0, 'visible'=>1, 'searchall'=>1, 'css'=>'minwidth200', 'help'=>"Help text", 'showoncombobox'=>'1',),
 		'description' => array('type'=>'text', 'label'=>'Description', 'enabled'=>'1', 'position'=>60, 'notnull'=>0, 'visible'=>3,),
 		'nb_contacts' => array('type'=>'integer', 'label'=>'DistributionListNbContactsInList', 'enabled'=>'1', 'position'=>61, 'notnull'=>1, 'visible'=>2, 'default'=>0),
-		'date_cloture' => array('type'=>'date', 'label'=>'DateClosing', 'enabled'=>'1', 'position'=>62, 'visible'=>4, 'default'=>0),
+		'date_cloture' => array('type'=>'date', 'label'=>'DateClosing', 'enabled'=>'1', 'position'=>62, 'visible'=>3, 'default'=>0),
 		'note_public' => array('type'=>'html', 'label'=>'NotePublic', 'enabled'=>'1', 'position'=>63, 'notnull'=>0, 'visible'=>0,),
 		'note_private' => array('type'=>'html', 'label'=>'NotePrivate', 'enabled'=>'1', 'position'=>64, 'notnull'=>0, 'visible'=>0,),
 		'date_creation' => array('type'=>'datetime', 'label'=>'DateCreation', 'enabled'=>'1', 'position'=>500, 'notnull'=>1, 'visible'=>-2,),

--- a/core/modules/modDistributionList.class.php
+++ b/core/modules/modDistributionList.class.php
@@ -64,7 +64,7 @@ class modDistributionList extends DolibarrModules
 		$this->editor_name = 'Editor name';
 		$this->editor_url = 'https://www.example.com';
 		// Possible values for version are: 'development', 'experimental', 'dolibarr', 'dolibarr_deprecated' or a version string like 'x.y.z'
-		$this->version = '1.1.1';
+		$this->version = '1.1.2';
 		// Url to the file with your last numberversion of this module
 		//$this->url_last_version = 'http://www.example.com/versionmodule.txt';
 

--- a/core/modules/modDistributionList.class.php
+++ b/core/modules/modDistributionList.class.php
@@ -64,7 +64,7 @@ class modDistributionList extends DolibarrModules
 		$this->editor_name = 'Editor name';
 		$this->editor_url = 'https://www.example.com';
 		// Possible values for version are: 'development', 'experimental', 'dolibarr', 'dolibarr_deprecated' or a version string like 'x.y.z'
-		$this->version = '1.1.2';
+		$this->version = '1.1.3';
 		// Url to the file with your last numberversion of this module
 		//$this->url_last_version = 'http://www.example.com/versionmodule.txt';
 

--- a/core/modules/modDistributionList.class.php
+++ b/core/modules/modDistributionList.class.php
@@ -64,7 +64,7 @@ class modDistributionList extends DolibarrModules
 		$this->editor_name = 'Editor name';
 		$this->editor_url = 'https://www.example.com';
 		// Possible values for version are: 'development', 'experimental', 'dolibarr', 'dolibarr_deprecated' or a version string like 'x.y.z'
-		$this->version = '1.1.0';
+		$this->version = '1.1.1';
 		// Url to the file with your last numberversion of this module
 		//$this->url_last_version = 'http://www.example.com/versionmodule.txt';
 

--- a/distributionlist_card.php
+++ b/distributionlist_card.php
@@ -400,17 +400,25 @@ if ($object->id > 0 && (empty($action) || ($action != 'edit' && $action != 'crea
 	if ($action == 'validate') {
 		$error = 0;
 
-		// We verify whether the object is provisionally numbering
-		$ref = substr($object->ref, 1, 4);
-		if ($ref == 'PROV') {
-			$numref = $object->getNextNumRef($soc);
-			if (empty($numref)) {
-				$error++;
-				setEventMessages($object->error, $object->errors, 'errors');
+		if ($object->nb_contacts > 0){
+			// We verify whether the object is provisionally numbering
+			$ref = substr($object->ref, 1, 4);
+			if ($ref == 'PROV') {
+				$numref = $object->getNextNumRef($soc);
+				if (empty($numref)) {
+					$error++;
+					setEventMessages($object->error, $object->errors, 'errors');
+				}
+			} else {
+				$numref = $object->ref;
 			}
 		} else {
-			$numref = $object->ref;
+			$error++;
+			setEventMessages($langs->transnoentities("NoContactInDistribListError"), null, 'warnings');
 		}
+
+
+
 
 		$text = $langs->trans('ConfirmValidateDistributionList', $numref);
 		if (!empty($conf->notification->enabled)) {

--- a/distributionlist_card.php
+++ b/distributionlist_card.php
@@ -431,7 +431,7 @@ if ($object->id > 0 && (empty($action) || ($action != 'edit' && $action != 'crea
 		if (!$error)
 			$formconfirm = $form->formconfirm($_SERVER["PHP_SELF"].'?id='.$object->id, $langs->trans('DistributionListValidate'), $text, 'confirm_validate', '', 0, 1);
 	}
-	// Clone confirmation
+	// Clone action
 	if ($action == 'clone') {
 		// Create an array for form
 		$formquestion = array();
@@ -444,9 +444,14 @@ if ($object->id > 0 && (empty($action) || ($action != 'edit' && $action != 'crea
 			// 'text' => $langs->trans("ConfirmClone"),
 			// array('type' => 'checkbox', 'name' => 'clone_content', 'label' => $langs->trans("CloneMainAttributes"), 'value' => 1),
 			// array('type' => 'checkbox', 'name' => 'update_prices', 'label' => $langs->trans("PuttingPricesUpToDate"), 'value' => 1),
-			array('type' => 'date', 'name' => 'date_cloture', 'label' => $langs->trans('DateClosing'), 'value'=>dol_now())
+			// array('type' => 'date', 'name' => 'date_cloture', 'label' => $langs->trans('DateClosing'), 'value'=>dol_now())
 		);
 		$formconfirm = $form->formconfirm($_SERVER["PHP_SELF"].'?id='.$object->id, $langs->trans('ToClose'), $langs->trans('ConfirmCloseDistributionList', $object->ref), 'confirm_close', $formquestion, 'yes', 1);
+	}
+
+	// Close confirmation
+	if ($action == 'confirm_close' && $confirm == 'yes' && $permissiontoadd) {
+		$object->date_cloture = dol_now();
 	}
 
 	if ($action == 'reopen') {

--- a/langs/fr_FR/distributionlist.lang
+++ b/langs/fr_FR/distributionlist.lang
@@ -83,3 +83,8 @@ MyPageName = Nom de ma page
 #
 MyWidget = Mon widget
 MyWidgetDescription = Description de mon widget
+
+#
+# Erreurs
+#
+NoContactInDistribListError=Des contacts doivent être ajoutés à la liste de diffusion avant de pouvoir la valider


### PR DESCRIPTION
### FIX : Retours Sprint 42

- Ajout du champ "Date de clôture" sur le formulaire de création 
- Ajout de l'impossibilité de valider une liste de diffusion lorsqu’aucun contact ne lui est affecté 
- Suppression du champ "Date de clôture" dans la pop-up de confirmation (sur clôture d'une liste de diffusion)
- Mise à jour automatique de la date de clôture, sur clôture d'une liste de diffusion