### PR TITLE
FIX : LDD Status feedback

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,6 +1,7 @@
 # CHANGELOG DISTRIBUTIONLIST FOR [DOLIBARR ERP CRM](https://www.dolibarr.org)
 
 ## Unreleased
+- FIX : Récupération des listes de diffusion au statut clôturé dans le select des listes de diffusions sur l'onglet "Destinataires" d'une campagne - *08/03/2022* - 1.3.1
 - FIX : Empêcher les doublons :
   - Conf DISTRIBUTIONLISTUNIQUELABEL : Rendre le libellé des listes de diffusion unique + message d'erreur et lien vers la liste existante avec le même nom
   - Onglet ajout des destinataires, afficher les filtres personnalisés par ordre alphabétique + empecher les doublons

--- a/core/modules/mailings/distributionlist.modules.php
+++ b/core/modules/mailings/distributionlist.modules.php
@@ -170,13 +170,15 @@ class mailing_distributionlist extends MailingTargets
 		$langs->load("DistributionList");
 
 		$distributionlist = new DistributionList($this->db);
-		$TDistributionList = $distributionlist->fetchAll('ASC', 'label',  0, 0, array('status'=>1));
+		$TDistributionList = $distributionlist->fetchAll('ASC', 'label',  0, 0, array('customsql'=> 'status IN (1,2)'));
 
 		$s = '<select name="filter_distributionlist" class="flat">';
 
-		foreach($TDistributionList as $id=>$distributionlist) {
-			$s .= '<option value="'.$id.'">'.$distributionlist->label.'</option>';
-		}
+        if (! empty($TDistributionList)) {
+            foreach($TDistributionList as $id=>$distributionlist) {
+                $s .= '<option value="'.$id.'">'.$distributionlist->label.'</option>';
+            }
+        }
 
 		$s .= '</select> ';
 

--- a/core/modules/modDistributionList.class.php
+++ b/core/modules/modDistributionList.class.php
@@ -64,7 +64,7 @@ class modDistributionList extends DolibarrModules
 		$this->editor_name = 'Editor name';
 		$this->editor_url = 'https://www.example.com';
 		// Possible values for version are: 'development', 'experimental', 'dolibarr', 'dolibarr_deprecated' or a version string like 'x.y.z'
-		$this->version = '1.3.0';
+		$this->version = '1.3.1';
 		// Url to the file with your last numberversion of this module
 		//$this->url_last_version = 'http://www.example.com/versionmodule.txt';
 


### PR DESCRIPTION
# FIX

Récupération des listes de diffusion au statut clôturé dans le select des listes de diffusions sur l'onglet "Destinataires" d'une campagne